### PR TITLE
feat: migrate Hetzner cluster autoscaler config from env var to file

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -1,17 +1,30 @@
 locals {
   cluster_autoscaler_enabled = length(local.cluster_autoscaler_nodepools) > 0
 
-  cluster_autoscaler_cluster_config = local.cluster_autoscaler_enabled ? {
-    imagesForArch = {
-      arm64 = local.image_label_selector,
-      amd64 = local.image_label_selector
-    },
-    nodeConfigs = {
-      for nodepool in local.cluster_autoscaler_nodepools : "${var.cluster_name}-${nodepool.name}" => {
-        cloudInit = data.talos_machine_configuration.cluster_autoscaler[nodepool.name].machine_configuration,
-        labels    = nodepool.labels
-        taints    = nodepool.taints
-      }
+  cluster_autoscaler_nodepools_manifest = local.cluster_autoscaler_enabled ? {
+    apiVersion = "v1"
+    kind       = "Secret"
+    type       = "Opaque"
+    metadata = {
+      name      = "hcloud-cluster-autoscaler"
+      namespace = "kube-system"
+    }
+    data = {
+      nodepools = base64encode(jsonencode(
+        {
+          imagesForArch = {
+            arm64 = local.image_label_selector,
+            amd64 = local.image_label_selector
+          },
+          nodeConfigs = {
+            for nodepool in local.cluster_autoscaler_nodepools : "${var.cluster_name}-${nodepool.name}" => {
+              cloudInit = data.talos_machine_configuration.cluster_autoscaler[nodepool.name].machine_configuration,
+              labels    = nodepool.labels
+              taints    = nodepool.taints
+            }
+          }
+        }
+      ))
     }
   } : null
 }
@@ -29,10 +42,6 @@ data "helm_template" "cluster_autoscaler" {
 
   set = [
     {
-      name  = "image.tag"
-      value = "v1.31.1"
-    },
-    {
       name  = "cloudProvider"
       value = "hetzner"
     },
@@ -45,8 +54,8 @@ data "helm_template" "cluster_autoscaler" {
       value = "token"
     },
     {
-      name  = "extraEnv.HCLOUD_CLUSTER_CONFIG"
-      value = base64encode(jsonencode(local.cluster_autoscaler_cluster_config))
+      name  = "extraEnv.HCLOUD_CLUSTER_CONFIG_FILE"
+      value = "/data/autoscaler/hcloud/nodepools"
     },
     {
       name  = "extraEnv.HCLOUD_SERVER_CREATION_TIMEOUT"
@@ -111,6 +120,18 @@ data "helm_template" "cluster_autoscaler" {
           region       = np.location
         }
       ]
+      extraVolumeSecrets = {
+        "hcloud-nodepools" = {
+          name      = "hcloud-cluster-autoscaler"
+          mountPath = "/data/autoscaler/hcloud"
+          items = [
+            {
+              key  = "nodepools"
+              path = "nodepools"
+            }
+          ]
+        }
+      }
     }),
     yamlencode(var.cluster_autoscaler_helm_values)
   ]
@@ -124,6 +145,10 @@ data "helm_template" "cluster_autoscaler" {
 locals {
   cluster_autoscaler_manifest = local.cluster_autoscaler_enabled ? {
     name     = "cluster-autoscaler"
-    contents = data.helm_template.cluster_autoscaler[0].manifest
+    contents = <<-EOF
+      ${data.helm_template.cluster_autoscaler[0].manifest}
+      ---
+      ${yamlencode(local.cluster_autoscaler_nodepools_manifest)}
+    EOF
   } : null
 }


### PR DESCRIPTION
- Replace HCLOUD_CLUSTER_CONFIG environment variable with HCLOUD_CLUSTER_CONFIG_FILE

This migration follows the new Hetzner cloud provider format documented at: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/hetzner/README.md