### PR TITLE
feat: upgrade Talos Linux to v1.10 and Kubernetes to v1.33 for v2.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolab
 ### :white_check_mark: Version Compatibility Matrix
 | Hcloud K8s |  K8s  | Talos | Talos CCM | Hcloud CCM | Hcloud CSI | Long-horn | Cilium | Ingress NGINX | Cert Mgr. | Auto-scaler |
 | :--------: | :---: | :---: | :-------: | :--------: | :--------: | :-------: | :----: | :-----------: | :-------: | :---------: |
-|  (**2**)   | 1.32  |  1.9  |    1.9    |    1.23    |    2.12    |   1.8.1   |  1.17  |     4.12      |   1.17    |    9.45     |
+|  (**2**)   | 1.33  |  1.10 |    1.10   |    1.26    |    2.16    |   1.8.2   |  1.17.5|     4.12.4    |   1.18.2  |    9.48     |
 |   **1**    | 1.31  |  1.8  |    1.8    |    1.21    |    2.10    |    1.8    |  1.17  |     4.12      |   1.15    |    9.38     |
 |   **0**    | 1.30  |  1.7  |    1.6    |    1.20    |    2.9     |   1.7.1   |  1.16  |    4.10.1     |   1.14    |    9.37     |
 
@@ -871,7 +871,7 @@ In this module, upgrades are conducted with care and conservatism. You will cons
 
 <!-- Roadmap -->
 ## :compass: Roadmap
-* [ ] **Upgrade to Talos 1.9 and Kubernetes 1.32**<br>
+* [X] **Upgrade to Talos 1.10 and Kubernetes 1.33**<br>
       Once all components have compatible versions, the upgrade can be performed.
 * [x] **Upgrade to Talos 1.8 and Kubernetes 1.31**<br>
       Once all components have compatible versions, the upgrade can be performed.

--- a/variables.tf
+++ b/variables.tf
@@ -493,7 +493,7 @@ variable "cluster_autoscaler_config_patches" {
 # Talos
 variable "talos_version" {
   type        = string
-  default     = "v1.8.4"
+  default     = "v1.10.5"
   description = "Specifies the version of Talos to be used in generated machine configurations."
 }
 
@@ -697,7 +697,7 @@ variable "talos_extra_remote_manifests" {
 # Talos Backup
 variable "talos_backup_version" {
   type        = string
-  default     = "v0.1.0-beta.2-1-g9ccc125"
+  default     = "v0.1.0-beta.3-1-g3022fec"
   description = "Specifies the version of Talos Backup to be used in generated machine configurations."
 }
 
@@ -773,7 +773,7 @@ variable "talos_backup_schedule" {
 # Kubernetes
 variable "kubernetes_version" {
   type        = string
-  default     = "v1.31.4"
+  default     = "v1.33.2"
   description = "Specifies the Kubernetes version to deploy."
 }
 


### PR DESCRIPTION
- Update Talos Linux version to 1.10
- Upgrade Kubernetes to v1.33
- Bump associated subcharts

Breaking changes:
- Review configuration files for any deprecated options
- Validate cluster compatibility before deployment