### PR TITLE
feat: add OIDC authentication and custom RBAC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,183 @@ talos_siderolabs_discovery_service_enabled = true
 For more details, refer to the [official Talos discovery guide](https://www.talos.dev/latest/talos-guides/discovery/).
 </details>
 
+<!-- Kubernetes RBAC -->
+<details>
+<summary><b>Kubernetes RBAC</b></summary>
+
+This module allows you to create custom Kubernetes RBAC (Role-Based Access Control) roles and cluster roles that define specific permissions for users and groups. RBAC controls what actions users can perform on which Kubernetes resources.  
+These custom roles can be used independently or combined with OIDC group mappings to automatically assign permissions based on user group membership from your identity provider.
+
+#### Example Configuration
+
+##### Cluster Roles (`rbac_cluster_roles`)
+
+```hcl
+rbac_cluster_roles = {
+  "cluster-role-name" = {
+    rules = [
+      {
+        api_groups = [""]                      # Core API group (empty string for core resources)
+        resources  = ["nodes"]                 # Cluster-wide resources this role can access
+        verbs      = ["get", "list", "watch"]  # Actions allowed on these resources
+      }
+    ]
+  }
+}
+```
+
+##### Namespaced Roles (`rbac_roles`)
+
+```hcl
+rbac_roles = {
+  "role-name" = {
+    namespace = "target-namespace"             # Namespace where the role will be created
+    rules = [
+      {
+        api_groups = [""]                      # Core API group (empty string for core resources)
+        resources  = ["pods", "services"]      # Resources this role can access
+        verbs      = ["get", "list", "watch"]  # Actions allowed on these resources
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+<!-- OIDC Cluster Authentication -->
+<details>
+<summary><b>OIDC Cluster Authentication</b></summary>
+
+The Kubernetes API server supports OIDC (OpenID Connect) authentication, allowing integration with external identity providers like Keycloak, Auth0, Authentik, Zitadel, etc.
+When enabled, users can authenticate using their existing organizational credentials instead of managing separate Kubernetes certificates or tokens.
+
+OIDC authentication works by validating JWT tokens issued by your identity provider, extracting user information and group memberships, and mapping them to Kubernetes RBAC roles.
+
+#### Example Configuration
+
+```hcl
+# OIDC Configuration
+oidc_enabled        = true                               # Enable OIDC authentication
+oidc_issuer_url     = "https://your-oidc-provider.com"   # Your OIDC provider issuer URL
+oidc_client_id      = "your-client-id"                   # Client ID registered in your OIDC provider
+oidc_username_claim = "preferred_username"               # OIDC JWT claim to extract username from
+oidc_groups_claim   = "groups"                           # OIDC JWT claim to extract user groups from
+oidc_groups_prefix  = "oidc:"                            # Prefix added to group names in K8s to avoid conflicts
+
+# Map OIDC groups to Kubernetes roles and cluster roles
+oidc_group_mappings = {                                  # Each key must match a OIDC provider group
+  "cluster-admins-group" = {                                   
+    cluster_roles = ["cluster-admin"]                    # Grant cluster-admin access
+  }
+  "developers-group" = {
+    cluster_roles = ["view"]                             # Grant cluster-wide view access
+    roles = [                                            # Grant namespace scoped roles
+      {
+        name      = "developer-role"                     # Custom role name
+        namespace = "development"                        # Namespace where role applies
+      }
+    ]
+  }
+}
+```
+
+#### Client Configuration with kubelogin
+
+Once OIDC is configured on your cluster, you'll need to configure your local kubectl to authenticate using OIDC tokens. This requires the [kubelogin](https://github.com/int128/kubelogin) plugin.
+
+##### Install kubelogin
+
+```bash
+# Homebrew (macOS and Linux)
+brew install kubelogin
+
+# Krew (macOS, Linux, Windows and ARM)
+kubectl krew install oidc-login
+
+# Chocolatey (Windows)
+choco install kubelogin
+```
+
+#### Test OIDC Authentication
+
+First, verify that your OIDC provider is returning proper JWT tokens. Replace the placeholder values with your actual OIDC configuration:
+
+```bash
+kubectl oidc-login setup \
+  --oidc-issuer-url=https://your-oidc-provider.com \
+  --oidc-client-id=your-client-id \
+  --oidc-client-secret=your-client-secret \           
+  --oidc-extra-scope=openid,email,profile             # Change the scopes according to your IDP
+```
+
+This will open your browser for authentication. After successful login, you should see a JWT token in your terminal that looks like:
+
+```json
+{
+  "aud": "your-client-id",
+  "email": "user@example.com",
+  "email_verified": true,
+  "exp": 1749867571,
+  "groups": [
+    "developers",
+    "kubernetes-users"
+  ],
+  "iat": 1749863971,
+  "iss": "https://your-oidc-provider.com",
+  "nonce": "random-nonce-string",
+  "sub": "user-unique-identifier"
+}
+```
+
+Verify that:
+
+- The `groups` array contains your expected groups
+- The `email` field matches your user email
+- `email_verified` is `true` (required by K8s)
+
+#### Configure kubectl
+
+Add a new user to your `~/.kube/config` file:
+
+```yaml
+users:
+- name: oidc-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: kubectl
+      args:
+        - oidc-login
+        - get-token
+        - --oidc-issuer-url=https://your-oidc-provider.com
+        - --oidc-client-id=your-client-id
+        - --oidc-client-secret=your-client-secret
+        - --oidc-extra-scope=groups
+        - --oidc-extra-scope=email
+        - --oidc-extra-scope=name
+```
+
+Update your context to use the new OIDC user:
+
+```yaml
+contexts:
+- context:
+    cluster: your-cluster
+    namespace: default
+    user: oidc-user          # Changed from certificate-based user
+  name: oidc@your-cluster    # Updated context name
+```
+
+Now you can switch to the OIDC context and authenticate using your identity provider:
+
+```bash
+kubectl config use-context your-cluster-oidc
+kubectl get pods  # This will trigger OIDC authentication
+```
+
+</details>
+
 <!-- Lifecycle -->
 ## :recycle: Lifecycle
 The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolabs/talos) does not support declarative upgrades of Talos or Kubernetes versions. This module compensates for these limitations using `talosctl` to implement the required functionalities. Any minor or major upgrades to Talos and Kubernetes will result in a major version change of this module. Please be aware that downgrades are typically neither supported nor tested.

--- a/oidc.tf
+++ b/oidc.tf
@@ -1,0 +1,61 @@
+locals {
+  # Create bindings for OIDC groups
+  oidc_manifests = var.oidc_enabled ? concat(
+
+    # Cluster Role bindings
+    flatten([
+      for oidc_group, mapping in var.oidc_group_mappings : [
+        for cluster_role in mapping.cluster_roles : yamlencode({
+          apiVersion = "rbac.authorization.k8s.io/v1"
+          kind       = "ClusterRoleBinding"
+          metadata = {
+            name = "${oidc_group}-${cluster_role}"
+          }
+          roleRef = {
+            apiGroup = "rbac.authorization.k8s.io"
+            kind     = "ClusterRole"
+            name     = cluster_role
+          }
+          subjects = [
+            {
+              apiGroup = "rbac.authorization.k8s.io"
+              kind     = "Group"
+              name     = "${var.oidc_groups_prefix}${oidc_group}"
+            }
+          ]
+        })
+      ]
+    ]),
+
+    # Role bindings
+    flatten([
+      for oidc_group, mapping in var.oidc_group_mappings : [
+        for role in mapping.roles : yamlencode({
+          apiVersion = "rbac.authorization.k8s.io/v1"
+          kind       = "RoleBinding"
+          metadata = {
+            name      = "${oidc_group}-${role.name}"
+            namespace = role.namespace
+          }
+          roleRef = {
+            apiGroup = "rbac.authorization.k8s.io"
+            kind     = "Role"
+            name     = role.name
+          }
+          subjects = [
+            {
+              apiGroup = "rbac.authorization.k8s.io"
+              kind     = "Group"
+              name     = "${var.oidc_groups_prefix}${oidc_group}"
+            }
+          ]
+        })
+      ]
+    ])
+  ) : []
+
+  oidc_manifest = length(local.oidc_manifests) > 0 ? {
+    name     = "talos-oidc"
+    contents = join("\n---\n", local.oidc_manifests)
+  } : null
+}

--- a/rbac.tf
+++ b/rbac.tf
@@ -1,0 +1,38 @@
+locals {
+  # Generate Kubernetes RBAC manifests
+  rbac_manifests = concat(
+    # Kubernetes namespaced roles
+    [for role_name, role_config in var.rbac_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "Role"
+      metadata = {
+        name      = role_name
+        namespace = role_config.namespace
+      }
+      rules = [for rule in role_config.rules : {
+        apiGroups = rule.api_groups
+        resources = rule.resources
+        verbs     = rule.verbs
+      }]
+    })],
+    # Kubernetes cluster roles 
+    [for role_name, role_config in var.rbac_cluster_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "ClusterRole"
+      metadata = {
+        name = role_name
+      }
+      rules = [for rule in role_config.rules : {
+        apiGroups = rule.api_groups
+        resources = rule.resources
+        verbs     = rule.verbs
+      }]
+    })]
+  )
+
+  rbac_manifest = length(local.rbac_manifests) > 0 ? {
+    name     = "talos-rbac"
+    contents = join("\n---\n", local.rbac_manifests)
+  } : null
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -829,6 +829,91 @@ variable "talos_ccm_version" {
   description = "Specifies the version of the Talos Cloud Controller Manager (CCM) to use. This version controls cloud-specific integration features in the Talos operating system."
 }
 
+# Talos OIDC Configuration
+variable "oidc_enabled" {
+  description = "Enable OIDC authentication for Kubernetes API server"
+  type        = bool
+  default     = false
+}
+
+variable "oidc_issuer_url" {
+  description = "URL of the OIDC provider (e.g., https://your-oidc-provider.com). Required when oidc_enabled is true"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.oidc_enabled == false || (var.oidc_enabled == true && var.oidc_issuer_url != "")
+    error_message = "oidc_issuer_url is required when oidc_enabled is true."
+  }
+}
+
+variable "oidc_client_id" {
+  description = "OIDC client ID that all tokens must be issued for. Required when oidc_enabled is true"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.oidc_enabled == false || (var.oidc_enabled == true && var.oidc_client_id != "")
+    error_message = "oidc_client_id is required when oidc_enabled is true."
+  }
+}
+
+variable "oidc_username_claim" {
+  description = "JWT claim to use as the username"
+  type        = string
+  default     = "sub"
+}
+
+variable "oidc_groups_claim" {
+  description = "JWT claim to use as the user's groups"
+  type        = string
+  default     = "groups"
+}
+
+variable "oidc_groups_prefix" {
+  description = "Prefix prepended to group claims to prevent clashes with existing names"
+  type        = string
+  default     = "oidc:"
+}
+
+variable "oidc_group_mappings" {
+  description = "Map OIDC groups to Kubernetes roles and cluster roles"
+  type = map(object({
+    cluster_roles = optional(list(string), [])
+    roles = optional(list(object({
+      name      = string
+      namespace = string
+    })), [])
+  }))
+  default = {}
+}
+
+# Kubernetes RBAC
+variable "rbac_roles" {
+  description = "Custom Kubernetes roles to create"
+  type = map(object({
+    namespace = string
+    rules = list(object({
+      api_groups = list(string)
+      resources  = list(string)
+      verbs      = list(string)
+    }))
+  }))
+  default = {}
+}
+
+variable "rbac_cluster_roles" {
+  description = "Custom Kubernetes cluster roles to create"
+  type = map(object({
+    rules = list(object({
+      api_groups = list(string)
+      resources  = list(string)
+      verbs      = list(string)
+    }))
+  }))
+  default = {}
+}
+
 
 # Hetzner Cloud
 variable "hcloud_token" {
@@ -1425,7 +1510,6 @@ variable "ingress_load_balancer_pools" {
     error_message = "The rdns_ipv6 must be a valid IPv6 reverse DNS domain: each segment must start and end with a letter or number, can contain hyphens, and each segment must be no longer than 63 characters. Supports dynamic substitution with placeholders: {{ cluster-domain }}, {{ cluster-name }}, {{ hostname }}, {{ id }}, {{ ip-labels }}, {{ ip-type }}, {{ pool }}, {{ role }}."
   }
 }
-
 
 # Miscellaneous
 variable "prometheus_operator_crds_enabled" {


### PR DESCRIPTION
- Add OIDC configuration variables for Kubernetes API server authentication
- Support for external identity providers (Keycloak, Auth0, Azure AD, etc.)
- Add custom RBAC roles and cluster roles creation
- Implement OIDC group to Kubernetes role bindings

This enables organizations to integrate their existing identity providers with Kubernetes authentication and automatically map user groups to appropriate RBAC permissions.