### PR TITLE
feat: add volumeExtraLabels support for Hcloud CSI v2.14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,14 @@ hcloud_csi_storage_class_extra_parameters = {
   "csi.storage.k8s.io/fstype" = "xfs"
   "fsFormatOption"            = "-i nrext64=1"
 }
+
+# Add default labels to all newly created volumes
+hcloud_csi_volume_extra_labels = {
+  "environment" = "production"
+  "team"        = "platform"
+  "backup"      = "enabled"
+}
+
 ```
 
 **Defining additional StorageClasses**

--- a/hcloud.tf
+++ b/hcloud.tf
@@ -122,6 +122,7 @@ data "helm_template" "hcloud_csi" {
             operator = "Exists"
           }
         ]
+        volumeExtraLabels = var.hcloud_csi_volume_extra_labels
       }
       storageClasses = concat(local.hcloud_csi_default_storage_class, var.hcloud_csi_additional_storage_classes)
     }),

--- a/variables.tf
+++ b/variables.tf
@@ -1055,6 +1055,12 @@ variable "hcloud_csi_additional_storage_classes" {
   default = []
 }
 
+variable "hcloud_csi_volume_extra_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Specifies default labels to apply to all newly created volumes. The value must be a map in the format key: value."
+}
+
 # Longhorn
 variable "longhorn_helm_repository" {
   type        = string


### PR DESCRIPTION
- Add new variable hcloud_csi_volume_extra_labels to configure default labels for all newly created volumes
- Add example configuration showing how to use volume extra labels

This feature is available in Hcloud CSI chart version 2.14+ and allows users to automatically apply custom labels to all volumes created by the CSI driver, useful for environment tagging, team assignment, and backup policies.